### PR TITLE
Fixed compatibiltiy with Python 2

### DIFF
--- a/SimpleAES/__init__.py
+++ b/SimpleAES/__init__.py
@@ -46,7 +46,7 @@ class SimpleAES(object):
             envvar = hashlib.sha256(_random_noise(16)).hexdigest()
             ciphertext = check_output([
                 'openssl', 'enc', '-e', '-aes-256-cbc', '-a',
-                '-salt', '-pass', 'env:{}'.format(envvar)],
+                '-salt', '-pass', 'env:{0}'.format(envvar)],
                 input_=string,
                 env={envvar: self._password})
             return ciphertext.strip()
@@ -63,7 +63,7 @@ class SimpleAES(object):
             envvar = hashlib.sha256(_random_noise(16)).hexdigest()
             plaintext = check_output([
                 'openssl', 'enc', '-d', '-aes-256-cbc', '-a', '-pass',
-                'env:{}'.format(envvar)],
+                'env:{0}'.format(envvar)],
                 input_=b64_ciphertext + '\n',
                 env={envvar: self._password})
             return plaintext


### PR DESCRIPTION
Omitting positional argument specifier in `str.format` was a feature of [Python 3.1](http://docs.python.org/dev/library/string.html#format-string-syntax).

This patch adds `0` in `{}` of `encrypt` and `decrypt` to enable compatibility with Python 2. (Tested with 2.6.6 on Debian 6)
